### PR TITLE
Use PREFIX in compile/link step too

### DIFF
--- a/oidc-agent.rb
+++ b/oidc-agent.rb
@@ -20,7 +20,7 @@ class OidcAgent < Formula
   # currently cannot depend on casks. It's included in the docu.
 
   def install
-    system "make"
+    system "make PREFIX=#{prefix}"
     system "make install PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
Dear all,

there an issue with installing `oidc-agent` on Macs with Apple Silicon. Homebrew moved the prefix directory from `/usr/local` to `/opt/homebrew` as mentioned in https://github.com/Homebrew/brew/issues/9177.

Due to the missing `PREFIX` in compile/link step in the `oidc-agent` Homebrew formula, the `oidc-agent` is trying to read the file `/usr/local/etc/oidc-agent/pubclients.config` because of https://github.com/indigo-dc/oidc-agent/blob/55d3c3289ba446e57e06c5ab171566870828cdf5/Makefile#L172 and fails. This pull request fixes the issue by setting PREFIX also during the compile/link step in the Homebrew formula. 

Thanks and  best regards,
Manuel